### PR TITLE
Remove undefined array

### DIFF
--- a/src/library/merge-geometry.js
+++ b/src/library/merge-geometry.js
@@ -33,7 +33,7 @@ function mergeSourceAttributes({ sourceAttributes }) {
     });
     const destAttributes = {};
     Array.from(propertyNames.keys()).map((name) => {
-        destAttributes[name] = BufferGeometryUtils.mergeBufferAttributes(allSourceAttributes.map((sourceAttributes) => sourceAttributes[name]).flat());
+        destAttributes[name] = BufferGeometryUtils.mergeBufferAttributes(allSourceAttributes.map((sourceAttributes) => sourceAttributes[name]).flat().filter((attr) => attr !== undefined));
     });
     return destAttributes;
 }


### PR DESCRIPTION
Sometimes, it is filled with the undefined attributes that are cause of crash, so I would like to filter undefined values in array.

![image](https://user-images.githubusercontent.com/80860637/186955744-35975109-8d85-4a8c-bb0b-1abc77eac6a1.png)